### PR TITLE
Add project storage tracking and consolidate scheduled jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+# Build
+go build ./...
+
+# Run locally (requires a real PostgreSQL and GCS bucket)
+DB_URL=postgres://user:pass@host/db BUCKET_NAME=my-bucket go run .
+
+# Apply database schema (first run or after schema changes)
+psql $DB_URL -f schema.sql
+```
+
+There are no tests in this repository. CI only builds and pushes a Docker image on push to `main`.
+
+## Architecture
+
+Single-binary Go service (`package main`) — all files compile together with no internal packages.
+
+### File map
+
+| File | Responsibility |
+|---|---|
+| `main.go` | Server bootstrap: connects DB + GCS, wires middleware, registers all HTTP routes |
+| `registry.go` | OCI Distribution Spec v1 implementation (`/v2/` routes) including chunked blob upload via GCS compose |
+| `api.go` | Management API (`/api/` routes) using arpc |
+| `auth.go` | Auth middleware + `checkPermission` / `getEmail` helpers that delegate to `api.deploys.app` with 30 s in-memory caching |
+| `gc.go` | `runBlobGC` — deletes unreferenced blobs older than 1 day |
+| `storage_usage.go` | `calculateProjectStorage` — aggregates blob sizes per project namespace |
+| `errors.go` | Shared `arpc.NewError` values (`errForbidden`, `errRepoNotFound`, etc.) |
+| `schema.sql` | PostgreSQL schema (apply manually; no migration tool) |
+
+### Request flow
+
+```
+HTTP → parapet (healthz, logger) → pgctx middleware (injects *sql.DB into ctx)
+         ├── /v2/   → authMiddleware → registryHandler (OCI spec)
+         ├── /api/  → apiAuthMiddleware → arpc router (management API)
+         └── /internal/  → internalAuth (Bearer token) → job handlers
+```
+
+### Key design decisions
+
+**arpc response envelope** — all `/api/` endpoints return `{"ok": true, "result": {...}}` on success or `{"ok": false, "error": {"message": "..."}}` on failure. Handler functions return `(*Result, error)` for endpoints with a body, or just `error` for void endpoints.
+
+**Repository naming** — the `repositories.name` column stores the full `{namespace}/{repo}` string. `namespace` is a redundant denormalized column used for project-scoped queries. Blobs and manifests reference `repository` using the full name.
+
+**Blob upload** — OCI chunked uploads land as numbered GCS objects (`_uploads/{uuid}/{n}`) then are composed into the final blob path. GCS limits compose to 32 sources, so the code stages multiple compose passes for large uploads.
+
+**Scheduled jobs** — three jobs exist: `indexManifests`, `runBlobGC`, `calculateProjectStorage`. They are triggered via `POST /internal/runAll` (single Cloud Scheduler target) or individually via their own `/internal/*` endpoints. All internal endpoints are protected by `INTERNAL_SECRET` bearer token (skipped if unset — local dev only).
+
+**Auth caching** — `checkPermission` and `getEmail` cache results in `cachestore` (in-process, 30 s TTL) to avoid hammering `api.deploys.app` on every request.
+
+**Context propagation** — long-running delete operations call `context.WithoutCancel(ctx)` so the deletion completes even if the HTTP client disconnects. The detached context still carries the pgctx DB connection.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Apply the schema before first run:
 psql $DB_URL -f schema.sql
 ```
 
+### Tables
+
+| Table | Description |
+|---|---|
+| `repositories` | Repository metadata (name, namespace, created_at) |
+| `manifests` | OCI manifests per repository |
+| `tags` | Tag → manifest digest mappings |
+| `blobs` | Blob metadata including size |
+| `manifest_blobs` | Manifest → blob references (rebuilt by `indexManifests`) |
+| `project_storage_usage` | Pre-calculated total blob storage per project namespace (updated by `calculateProjectStorage`) |
+
 ## API
 
 ### Registry (`/v2/`)
@@ -100,6 +111,22 @@ List manifests for a repository with their digest and creation time.
 
 Requires `registry.get` permission.
 
+#### `POST /api/getProjectStorage`
+
+Get the pre-calculated total blob storage used across all repositories in a project. The value is updated once per day by the `calculateProjectStorage` scheduler job. Returns `size: 0` with no `updatedAt` if the job has not run yet.
+
+```json
+{ "project": "my-project" }
+```
+
+Response:
+
+```json
+{ "size": 1073741824, "updatedAt": "2024-01-15T03:00:00Z" }
+```
+
+Requires `registry.get` permission.
+
 #### `POST /api/deleteManifest`
 
 Delete a single manifest by digest, including all tags that point to it and their GCS objects. Blobs referenced by the manifest are **not** deleted immediately — they are cleaned up by the blob GC.
@@ -124,25 +151,68 @@ Requires `registry.push` permission.
 
 ### `POST /internal/indexManifests`
 
-Reads every manifest that has no `manifest_blobs` rows yet, fetches its content from GCS, and records which blobs it references. Intended to be called by Cloud Scheduler rather than run as a background goroutine, so only one replica processes the job at a time.
+Reads every manifest that has no `manifest_blobs` rows yet, fetches its content from GCS, and records which blobs it references. Runs as part of `POST /internal/runAll`.
 
 Protected by `Authorization: Bearer <INTERNAL_SECRET>`. If `INTERNAL_SECRET` is not set the check is skipped (local dev only).
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `INTERNAL_SECRET` | no | — | Bearer token required on the `Authorization` header |
-
 Returns `204 No Content` on success.
+
+To trigger manually:
+
+```sh
+curl -X POST https://registry.deploys.app/internal/indexManifests \
+  -H "Authorization: Bearer <INTERNAL_SECRET>"
+```
+
+### `POST /internal/runBlobGC`
+
+Deletes blobs that are not referenced by any manifest and are older than 1 day. The 1-day grace period covers blobs that have been uploaded but whose manifest push is still in flight. Runs as part of `POST /internal/runAll`.
+
+Returns `204 No Content` on success. Protected by the same `INTERNAL_SECRET` bearer token.
+
+To trigger manually:
+
+```sh
+curl -X POST https://registry.deploys.app/internal/runBlobGC \
+  -H "Authorization: Bearer <INTERNAL_SECRET>"
+```
+
+### `POST /internal/calculateProjectStorage`
+
+Calculates the total blob storage used by each project namespace and stores the result in the `project_storage_usage` table. Results are served via `POST /api/getProjectStorage`.
+
+Because the `blobs` table can be very large, this is designed to run once per day rather than on every API request.
+
+Returns `204 No Content` on success. Protected by the same `INTERNAL_SECRET` bearer token.
+
+To trigger manually:
+
+```sh
+curl -X POST https://registry.deploys.app/internal/calculateProjectStorage \
+  -H "Authorization: Bearer <INTERNAL_SECRET>"
+```
+
+### `POST /internal/runAll`
+
+Runs all scheduled jobs sequentially in a single HTTP call:
+
+1. `indexManifests`
+2. `runBlobGC`
+3. `calculateProjectStorage`
+
+Use this as the single Cloud Scheduler target so only one scheduler job is needed. If any step fails the endpoint returns `500` immediately (remaining steps are skipped) and the error is logged.
+
+Returns `204 No Content` on success. Protected by the same `INTERNAL_SECRET` bearer token.
 
 #### Cloud Scheduler setup
 
-Create a scheduler job that calls the endpoint daily. Replace the placeholders with your actual values.
+Replace the individual per-job scheduler entries with a single job targeting `/internal/runAll`:
 
 ```sh
-gcloud scheduler jobs create http registry-index-manifests \
+gcloud scheduler jobs create http registry-run-all \
   --location=asia-southeast1 \
   --schedule="0 2 * * *" \
-  --uri="https://registry.deploys.app/internal/indexManifests" \
+  --uri="https://registry.deploys.app/internal/runAll" \
   --http-method=POST \
   --headers="Authorization=Bearer <INTERNAL_SECRET>" \
   --attempt-deadline=30m \
@@ -152,42 +222,16 @@ gcloud scheduler jobs create http registry-index-manifests \
 To update the schedule or secret on an existing job:
 
 ```sh
-gcloud scheduler jobs update http registry-index-manifests \
+gcloud scheduler jobs update http registry-run-all \
   --location=asia-southeast1 \
   --schedule="0 2 * * *" \
   --headers="Authorization=Bearer <INTERNAL_SECRET>"
 ```
 
-To trigger the job immediately (e.g. after initial deploy):
+To trigger immediately (e.g. after initial deploy):
 
 ```sh
-gcloud scheduler jobs run registry-index-manifests \
-  --location=asia-southeast1
-```
-
-### `POST /internal/runBlobGC`
-
-Deletes blobs that are not referenced by any manifest and are older than 1 day. The 1-day grace period covers blobs that have been uploaded but whose manifest push is still in flight.
-
-Returns `204 No Content` on success. Protected by the same `INTERNAL_SECRET` bearer token as `indexManifests`.
-
-#### Cloud Scheduler setup
-
-```sh
-gcloud scheduler jobs create http registry-blob-gc \
-  --location=asia-southeast1 \
-  --schedule="0 3 * * *" \
-  --uri="https://registry.deploys.app/internal/runBlobGC" \
-  --http-method=POST \
-  --headers="Authorization=Bearer <INTERNAL_SECRET>" \
-  --attempt-deadline=30m \
-  --time-zone="UTC"
-```
-
-To trigger manually:
-
-```sh
-gcloud scheduler jobs run registry-blob-gc \
+gcloud scheduler jobs run registry-run-all \
   --location=asia-southeast1
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,45 +75,7 @@ All management endpoints accept `POST` with `Content-Type: application/json` and
 
 List repositories in a project namespace.
 
-```json
-{ "project": "my-project" }
-```
-
-Requires `registry.list` permission.
-
-#### `POST /api/get`
-
-Get repository info and total blob storage size.
-
-```json
-{ "project": "my-project", "repository": "my-image" }
-```
-
-Requires `registry.get` permission.
-
-#### `POST /api/getTags`
-
-List tags for a repository with their digest and creation time.
-
-```json
-{ "project": "my-project", "repository": "my-image" }
-```
-
-Requires `registry.get` permission.
-
-#### `POST /api/getManifests`
-
-List manifests for a repository with their digest and creation time.
-
-```json
-{ "project": "my-project", "repository": "my-image" }
-```
-
-Requires `registry.get` permission.
-
-#### `POST /api/getProjectStorage`
-
-Get the pre-calculated total blob storage used across all repositories in a project. The value is updated once per day by the `calculateProjectStorage` scheduler job. Returns `size: 0` with no `updatedAt` if the job has not run yet.
+Request:
 
 ```json
 { "project": "my-project" }
@@ -122,7 +84,115 @@ Get the pre-calculated total blob storage used across all repositories in a proj
 Response:
 
 ```json
-{ "size": 1073741824, "updatedAt": "2024-01-15T03:00:00Z" }
+{
+  "ok": true,
+  "result": {
+    "items": [
+      { "name": "my-image", "createdAt": "2024-01-15T00:00:00Z" }
+    ]
+  }
+}
+```
+
+Requires `registry.list` permission.
+
+#### `POST /api/get`
+
+Get repository info and total blob storage size.
+
+Request:
+
+```json
+{ "project": "my-project", "repository": "my-image" }
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "name": "my-image",
+    "size": 1073741824,
+    "createdAt": "2024-01-15T00:00:00Z"
+  }
+}
+```
+
+Requires `registry.get` permission.
+
+#### `POST /api/getTags`
+
+List tags for a repository with their digest and creation time.
+
+Request:
+
+```json
+{ "project": "my-project", "repository": "my-image" }
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "name": "my-image",
+    "items": [
+      { "tag": "latest", "digest": "sha256:abc123...", "createdAt": "2024-01-15T00:00:00Z" }
+    ]
+  }
+}
+```
+
+Requires `registry.get` permission.
+
+#### `POST /api/getManifests`
+
+List manifests for a repository with their digest and creation time.
+
+Request:
+
+```json
+{ "project": "my-project", "repository": "my-image" }
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "name": "my-image",
+    "items": [
+      { "digest": "sha256:abc123...", "createdAt": "2024-01-15T00:00:00Z" }
+    ]
+  }
+}
+```
+
+Requires `registry.get` permission.
+
+#### `POST /api/getProjectStorage`
+
+Get the pre-calculated total blob storage used across all repositories in a project. The value is updated once per day by the `calculateProjectStorage` scheduler job. Returns `size: 0` with no `updatedAt` if the job has not run yet.
+
+Request:
+
+```json
+{ "project": "my-project" }
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "size": 1073741824,
+    "updatedAt": "2024-01-15T03:00:00Z"
+  }
+}
 ```
 
 Requires `registry.get` permission.
@@ -131,8 +201,16 @@ Requires `registry.get` permission.
 
 Delete a single manifest by digest, including all tags that point to it and their GCS objects. Blobs referenced by the manifest are **not** deleted immediately — they are cleaned up by the blob GC.
 
+Request:
+
 ```json
 { "project": "my-project", "repository": "my-image", "digest": "sha256:abc123..." }
+```
+
+Response:
+
+```json
+{ "ok": true }
 ```
 
 Requires `registry.push` permission.
@@ -141,8 +219,34 @@ Requires `registry.push` permission.
 
 Delete a repository and all its data — manifests, tags, blobs, and the corresponding GCS objects. The operation continues to completion even if the client disconnects or the request times out.
 
+Request:
+
 ```json
 { "project": "my-project", "repository": "my-image" }
+```
+
+Response:
+
+```json
+{ "ok": true }
+```
+
+Requires `registry.push` permission.
+
+#### `POST /api/untag`
+
+Remove a single tag from a repository.
+
+Request:
+
+```json
+{ "project": "my-project", "repository": "my-image", "tag": "latest" }
+```
+
+Response:
+
+```json
+{ "ok": true }
 ```
 
 Requires `registry.push` permission.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,62 @@
+# SKILL.md
+
+Lessons learned from past mistakes in this repository.
+
+## arpc response envelope
+
+All `/api/` response examples in documentation must wrap the payload in the arpc envelope:
+
+```json
+{ "ok": true, "result": { ... } }
+```
+
+Void handlers (returning only `error`) produce:
+
+```json
+{ "ok": true }
+```
+
+Never document the inner payload alone — always show the full envelope.
+
+## Database error handling
+
+When using `pgctx.QueryRow(...).Scan(...)`, distinguish `sql.ErrNoRows` from real database errors. Never silently swallow all errors:
+
+```go
+err := pgctx.QueryRow(ctx, ...).Scan(...)
+if errors.Is(err, sql.ErrNoRows) {
+    // expected: no data yet
+    return &result{}, nil
+}
+if err != nil {
+    return nil, err  // real DB error — propagate
+}
+```
+
+Always use `errors.Is` (not `==`) for error comparison to correctly handle wrapped errors.
+
+## Bulk upserts with pgstmt
+
+Use `pgstmt.Insert` for multi-row upserts instead of a per-row `Exec` loop. Use `OnConflictOnConstraint(...).DoUpdate(...)` with `ToRaw` for raw SQL expressions like `excluded.col` and `now()`. Use `pgstmt.Default` for columns covered by a schema default (no placeholder consumed):
+
+```go
+pgstmt.Insert(func(b pgstmt.InsertStatement) {
+    b.Into("table")
+    b.Columns("col1", "col2", "updated_at")
+    for _, row := range chunk {
+        b.Value(row.col1, row.col2, pgstmt.Default)
+    }
+    b.OnConflictOnConstraint("table_pkey").DoUpdate(func(b pgstmt.UpdateStatement) {
+        b.Set("col2").ToRaw("excluded.col2")
+        b.Set("updated_at").ToRaw("now()")
+    })
+}).ExecWith(ctx)
+```
+
+Chunk rows to avoid PostgreSQL's 65535-placeholder limit. Use `slices.Chunk` from stdlib:
+
+```go
+for chunk := range slices.Chunk(rows, 1000) {
+    // pgstmt.Insert(...)
+}
+```

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strings"
@@ -307,9 +308,12 @@ func (a *App) apiGetProjectStorage(ctx context.Context, req *apiGetProjectStorag
 		from project_storage_usage
 		where namespace = $1
 	`, req.Project).Scan(&size, &updatedAt)
-	if err != nil {
+	if err == sql.ErrNoRows {
 		// No record yet — job hasn't run or project has no data
 		return &apiGetProjectStorageResult{Size: 0}, nil
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiGetProjectStorageResult{

--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -308,7 +309,7 @@ func (a *App) apiGetProjectStorage(ctx context.Context, req *apiGetProjectStorag
 		from project_storage_usage
 		where namespace = $1
 	`, req.Project).Scan(&size, &updatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		// No record yet — job hasn't run or project has no data
 		return &apiGetProjectStorageResult{Size: 0}, nil
 	}

--- a/api.go
+++ b/api.go
@@ -22,6 +22,7 @@ func (a *App) mountAPI(mux *http.ServeMux) {
 	api.Handle("POST /api/get", m.Handler(a.apiGet))
 	api.Handle("POST /api/getTags", m.Handler(a.apiGetTags))
 	api.Handle("POST /api/getManifests", m.Handler(a.apiGetManifests))
+	api.Handle("POST /api/getProjectStorage", m.Handler(a.apiGetProjectStorage))
 	api.Handle("POST /api/delete", m.Handler(a.apiDelete))
 	api.Handle("POST /api/deleteManifest", m.Handler(a.apiDeleteManifest))
 	api.Handle("POST /api/untag", m.Handler(a.apiUntag))
@@ -52,7 +53,7 @@ type apiListResult struct {
 
 func (a *App) apiList(ctx context.Context, req *apiListRequest) (*apiListResult, error) {
 	if !checkPermission(ctx, req.Project, permList) {
-		return nil, arpc.NewError("iam: forbidden")
+		return nil, errForbidden
 	}
 
 	var items []apiListItem
@@ -109,7 +110,7 @@ type apiGetResult struct {
 
 func (a *App) apiGet(ctx context.Context, req *apiGetRequest) (*apiGetResult, error) {
 	if !checkPermission(ctx, req.Project, permGet) {
-		return nil, arpc.NewError("iam: forbidden")
+		return nil, errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -122,7 +123,7 @@ func (a *App) apiGet(ctx context.Context, req *apiGetRequest) (*apiGetResult, er
 		where name = $1 and namespace = $2
 	`, fullName, req.Project).Scan(&name, &createdAt)
 	if err != nil {
-		return nil, arpc.NewError("repository not found")
+		return nil, errRepoNotFound
 	}
 
 	var size int64
@@ -167,7 +168,7 @@ type apiGetTagsResult struct {
 
 func (a *App) apiGetTags(ctx context.Context, req *apiGetTagsRequest) (*apiGetTagsResult, error) {
 	if !checkPermission(ctx, req.Project, permGet) {
-		return nil, arpc.NewError("iam: forbidden")
+		return nil, errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -177,7 +178,7 @@ func (a *App) apiGetTags(ctx context.Context, req *apiGetTagsRequest) (*apiGetTa
 		select name from repositories where name = $1 and namespace = $2
 	`, fullName, req.Project).Scan(&repoName)
 	if err != nil {
-		return nil, arpc.NewError("repository not found")
+		return nil, errRepoNotFound
 	}
 
 	var items []apiTagItem
@@ -236,7 +237,7 @@ type apiGetManifestsResult struct {
 
 func (a *App) apiGetManifests(ctx context.Context, req *apiGetManifestsRequest) (*apiGetManifestsResult, error) {
 	if !checkPermission(ctx, req.Project, permGet) {
-		return nil, arpc.NewError("iam: forbidden")
+		return nil, errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -246,7 +247,7 @@ func (a *App) apiGetManifests(ctx context.Context, req *apiGetManifestsRequest) 
 		select name from repositories where name = $1 and namespace = $2
 	`, fullName, req.Project).Scan(&repoName)
 	if err != nil {
-		return nil, arpc.NewError("repository not found")
+		return nil, errRepoNotFound
 	}
 
 	var items []apiManifestItem
@@ -276,6 +277,47 @@ func (a *App) apiGetManifests(ctx context.Context, req *apiGetManifestsRequest) 
 	}, nil
 }
 
+// getProjectStorage
+
+type apiGetProjectStorageRequest struct {
+	Project string `json:"project"`
+}
+
+func (r *apiGetProjectStorageRequest) Valid() error {
+	if r.Project == "" {
+		return arpc.NewError("project required")
+	}
+	return nil
+}
+
+type apiGetProjectStorageResult struct {
+	Size      int64      `json:"size"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+}
+
+func (a *App) apiGetProjectStorage(ctx context.Context, req *apiGetProjectStorageRequest) (*apiGetProjectStorageResult, error) {
+	if !checkPermission(ctx, req.Project, permGet) {
+		return nil, errForbidden
+	}
+
+	var size int64
+	var updatedAt time.Time
+	err := pgctx.QueryRow(ctx, `
+		select size, updated_at
+		from project_storage_usage
+		where namespace = $1
+	`, req.Project).Scan(&size, &updatedAt)
+	if err != nil {
+		// No record yet — job hasn't run or project has no data
+		return &apiGetProjectStorageResult{Size: 0}, nil
+	}
+
+	return &apiGetProjectStorageResult{
+		Size:      size,
+		UpdatedAt: &updatedAt,
+	}, nil
+}
+
 // delete
 
 type apiDeleteRequest struct {
@@ -295,7 +337,7 @@ func (r *apiDeleteRequest) Valid() error {
 
 func (a *App) apiDelete(ctx context.Context, req *apiDeleteRequest) error {
 	if !checkPermission(ctx, req.Project, permPush) {
-		return arpc.NewError("iam: forbidden")
+		return errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -307,7 +349,7 @@ func (a *App) apiDelete(ctx context.Context, req *apiDeleteRequest) error {
 		return err
 	}
 	if !exists {
-		return arpc.NewError("repository not found")
+		return errRepoNotFound
 	}
 
 	// Detach from the request context so the deletion runs to completion
@@ -372,7 +414,7 @@ func (r *apiDeleteManifestRequest) Valid() error {
 
 func (a *App) apiDeleteManifest(ctx context.Context, req *apiDeleteManifestRequest) error {
 	if !checkPermission(ctx, req.Project, permPush) {
-		return arpc.NewError("iam: forbidden")
+		return errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -384,7 +426,7 @@ func (a *App) apiDeleteManifest(ctx context.Context, req *apiDeleteManifestReque
 		return err
 	}
 	if !exists {
-		return arpc.NewError("manifest not found")
+		return errManifestNotFound
 	}
 
 	// Detach from the request context so the deletion runs to completion
@@ -465,7 +507,7 @@ func (r *apiUntagRequest) Valid() error {
 
 func (a *App) apiUntag(ctx context.Context, req *apiUntagRequest) error {
 	if !checkPermission(ctx, req.Project, permPush) {
-		return arpc.NewError("iam: forbidden")
+		return errForbidden
 	}
 
 	fullName := req.Project + "/" + req.Repository
@@ -477,7 +519,7 @@ func (a *App) apiUntag(ctx context.Context, req *apiUntagRequest) error {
 		return err
 	}
 	if !exists {
-		return arpc.NewError("tag not found")
+		return errTagNotFound
 	}
 
 	// Delete the tag-named GCS object (best-effort; ignore if already gone)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/acoshift/arpc/v2"
+
+var (
+	errForbidden        = arpc.NewError("iam: forbidden")
+	errRepoNotFound     = arpc.NewError("repository not found")
+	errManifestNotFound = arpc.NewError("manifest not found")
+	errTagNotFound      = arpc.NewError("tag not found")
+)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,38 @@ func main() {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
+	mux.HandleFunc("POST /internal/calculateProjectStorage", func(w http.ResponseWriter, r *http.Request) {
+		if !internalAuth(w, r) {
+			return
+		}
+		if err := app.calculateProjectStorage(r.Context()); err != nil {
+			slog.Error("calculateProjectStorage", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("POST /internal/runAll", func(w http.ResponseWriter, r *http.Request) {
+		if !internalAuth(w, r) {
+			return
+		}
+		ctx := r.Context()
+		for _, job := range []struct {
+			name string
+			fn   func(context.Context) error
+		}{
+			{"indexManifests", app.rebuildManifestBlobsIndex},
+			{"runBlobGC", app.runBlobGC},
+			{"calculateProjectStorage", app.calculateProjectStorage},
+		} {
+			if err := job.fn(ctx); err != nil {
+				slog.Error(job.name, "error", err)
+				http.Error(w, job.name+": "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
 
 	port := config.StringDefault("PORT", "8080")
 	slog.Info("start registry", "addr", ":"+port)

--- a/schema.sql
+++ b/schema.sql
@@ -40,3 +40,9 @@ create table manifest_blobs (
 	foreign key (repository, manifest_digest) references manifests (repository, digest)
 );
 create index manifest_blobs_blob_idx on manifest_blobs (repository, blob_digest);
+
+create table project_storage_usage (
+	namespace  text        not null primary key,
+	size       bigint      not null default 0,
+	updated_at timestamptz not null default now()
+);

--- a/storage_usage.go
+++ b/storage_usage.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/acoshift/pgsql"
 	"github.com/acoshift/pgsql/pgctx"
 	"github.com/acoshift/pgsql/pgstmt"
 )
-
-const storageChunkSize = 1000
 
 // calculateProjectStorage sums blob sizes per project namespace and upserts
 // the result into project_storage_usage. Intended to run once per day via
@@ -46,8 +45,7 @@ func (a *App) calculateProjectStorage(ctx context.Context) error {
 		return nil
 	}
 
-	for i := 0; i < len(usages); i += storageChunkSize {
-		chunk := usages[i:min(i+storageChunkSize, len(usages))]
+	for chunk := range slices.Chunk(usages, 1000) {
 		_, err := pgstmt.Insert(func(b pgstmt.InsertStatement) {
 			b.Into("project_storage_usage")
 			b.Columns("namespace", "size", "updated_at")

--- a/storage_usage.go
+++ b/storage_usage.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/acoshift/pgsql"
 	"github.com/acoshift/pgsql/pgctx"
+	"github.com/acoshift/pgsql/pgstmt"
 )
+
+const storageChunkSize = 1000
 
 // calculateProjectStorage sums blob sizes per project namespace and upserts
 // the result into project_storage_usage. Intended to run once per day via
@@ -43,13 +46,21 @@ func (a *App) calculateProjectStorage(ctx context.Context) error {
 		return nil
 	}
 
-	for _, u := range usages {
-		if _, err := pgctx.Exec(ctx, `
-			insert into project_storage_usage (namespace, size, updated_at)
-			values ($1, $2, now())
-			on conflict (namespace) do update set size = $2, updated_at = now()
-		`, u.namespace, u.size); err != nil {
-			return fmt.Errorf("calculate project storage: upsert %s: %w", u.namespace, err)
+	for i := 0; i < len(usages); i += storageChunkSize {
+		chunk := usages[i:min(i+storageChunkSize, len(usages))]
+		_, err := pgstmt.Insert(func(b pgstmt.InsertStatement) {
+			b.Into("project_storage_usage")
+			b.Columns("namespace", "size", "updated_at")
+			for _, u := range chunk {
+				b.Value(u.namespace, u.size, pgstmt.Default)
+			}
+			b.OnConflictOnConstraint("project_storage_usage_pkey").DoUpdate(func(b pgstmt.UpdateStatement) {
+				b.Set("size").ToRaw("excluded.size")
+				b.Set("updated_at").ToRaw("now()")
+			})
+		}).ExecWith(ctx)
+		if err != nil {
+			return fmt.Errorf("calculate project storage: upsert: %w", err)
 		}
 	}
 

--- a/storage_usage.go
+++ b/storage_usage.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/acoshift/pgsql"
+	"github.com/acoshift/pgsql/pgctx"
+)
+
+// calculateProjectStorage sums blob sizes per project namespace and upserts
+// the result into project_storage_usage. Intended to run once per day via
+// the /internal/runAll scheduler endpoint.
+func (a *App) calculateProjectStorage(ctx context.Context) error {
+	slog.Info("calculate project storage: start")
+
+	type projectUsage struct {
+		namespace string
+		size      int64
+	}
+
+	var usages []projectUsage
+	err := pgctx.Iter(ctx, func(scan pgsql.Scanner) error {
+		var u projectUsage
+		if err := scan(&u.namespace, &u.size); err != nil {
+			return err
+		}
+		usages = append(usages, u)
+		return nil
+	}, `
+		select r.namespace, coalesce(sum(b.size), 0)
+		from repositories r
+		left join blobs b on b.repository = r.name
+		group by r.namespace
+	`)
+	if err != nil {
+		return fmt.Errorf("calculate project storage: query: %w", err)
+	}
+
+	if len(usages) == 0 {
+		slog.Info("calculate project storage: no projects found")
+		return nil
+	}
+
+	for _, u := range usages {
+		if _, err := pgctx.Exec(ctx, `
+			insert into project_storage_usage (namespace, size, updated_at)
+			values ($1, $2, now())
+			on conflict (namespace) do update set size = $2, updated_at = now()
+		`, u.namespace, u.size); err != nil {
+			return fmt.Errorf("calculate project storage: upsert %s: %w", u.namespace, err)
+		}
+	}
+
+	slog.Info("calculate project storage: complete", "projects", len(usages))
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR adds project-level storage usage tracking and consolidates the three scheduled maintenance jobs (`indexManifests`, `runBlobGC`, `calculateProjectStorage`) into a single `/internal/runAll` endpoint. It also improves documentation and refactors error handling.

## Key Changes

- **New storage tracking**: Added `project_storage_usage` table and `calculateProjectStorage` job that aggregates blob sizes per project namespace once daily. Results are served via new `POST /api/getProjectStorage` endpoint.

- **Consolidated scheduler jobs**: Introduced `POST /internal/runAll` that runs all three maintenance jobs sequentially in a single HTTP call. This allows Cloud Scheduler to target a single endpoint instead of three separate ones, ensuring only one replica processes jobs at a time.

- **Improved error handling**: Extracted common `arpc.NewError` values into `errors.go` (`errForbidden`, `errRepoNotFound`, `errManifestNotFound`, `errTagNotFound`) to reduce duplication and ensure consistency across API handlers.

- **Enhanced documentation**: 
  - Added database schema table reference in README
  - Added request/response examples for all API endpoints
  - Documented the new `getProjectStorage` endpoint and `calculateProjectStorage` job
  - Updated Cloud Scheduler setup to use the consolidated `/internal/runAll` endpoint
  - Added `CLAUDE.md` with architecture overview and file map for AI-assisted development

- **Individual job endpoints preserved**: The original `/internal/indexManifests` and `/internal/runBlobGC` endpoints remain available for manual triggering, but Cloud Scheduler should target `/internal/runAll`.

## Implementation Details

- `calculateProjectStorage` uses a single SQL query to group repositories by namespace and sum their blob sizes, then upserts results into `project_storage_usage`
- The `apiGetProjectStorage` handler returns `size: 0` with no `updatedAt` if the job hasn't run yet (graceful degradation)
- All internal endpoints continue to use the same `INTERNAL_SECRET` bearer token authentication
- The consolidated `runAll` endpoint fails fast: if any job returns an error, remaining jobs are skipped and a 500 response is returned

https://claude.ai/code/session_01519esfFv6QWB1GJxhBAk9D