### PR TITLE
Allow unauthenticated requests through /v2/ ping for allUsers pull access

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -139,7 +139,7 @@ func authMiddleware(next http.Handler) http.Handler {
 
 		path := r.URL.Path
 		if path == "/v2/" {
-			if auth == "" || getEmail(auth) == "" {
+			if auth != "" && getEmail(auth) == "" {
 				registryUnauthorized(w, r)
 				return
 			}


### PR DESCRIPTION
## Summary

- `/v2/` ping now returns 200 for anonymous requests (previously returned 401)
- Requests with invalid/bad credentials are still rejected at `/v2/`

## Why

Docker's protocol: ping `/v2/` first, and if it gets a 401 it triggers a credentials challenge. With no credentials configured, Docker aborts with `no basic auth credentials` before ever attempting the actual manifest/blob request unauthenticated.

By returning 200 from `/v2/` for anonymous requests, Docker proceeds to the manifest request without credentials. The `allUsers` permission check then happens at the namespace-scoped path via `checkPermission` calling the auth API without an Authorization header.

## Reviewer notes

- Only the `/v2/` ping behaviour changes; namespace-scoped permission checks are unchanged.
- A request with a present-but-invalid token still gets a 401 at `/v2/`.