### PR TITLE
Add deploy workflow for GKE

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,24 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches: [main]
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+    - uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+    - uses: google-github-actions/get-gke-credentials@v2
+      with:
+        project_id: ${{ vars.GKE_PROJECT }}
+        cluster_name: ${{ vars.GKE_CLUSTER }}
+        location: ${{ vars.GKE_LOCATION }}
+    - name: Deploy
+      env:
+        IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/registry:${{ github.event.workflow_run.head_sha }}
+      run: kubectl set image -n deployer deployment/registry app=$IMAGE


### PR DESCRIPTION
## Summary
- New `.github/workflows/deploy.yaml` that triggers on `workflow_run` after the `Build` workflow succeeds on `main`.
- Runs `kubectl set image -n deployer deployment/registry app=$IMAGE` against the GKE cluster, using the SHA that `Build` actually pushed (`github.event.workflow_run.head_sha`).
- Cluster targeting is configurable via repo variables so the cluster can live in a different GCP project from the auth credentials.

## Required configuration
Set these as GitHub Actions **variables** on the repo:
- `GKE_PROJECT` — project hosting the GKE cluster
- `GKE_CLUSTER` — cluster name
- `GKE_LOCATION` — cluster region/zone

Reuses the existing `GOOGLE_CREDENTIALS` secret. The service account needs `container.clusters.get` on the target project plus RBAC to patch the `registry` deployment in the `deployer` namespace.

## Test plan
- [ ] Set `GKE_PROJECT`, `GKE_CLUSTER`, `GKE_LOCATION` repo vars.
- [ ] Merge to `main`; confirm `Build` runs and pushes the image.
- [ ] Confirm `Deploy` triggers via `workflow_run`, authenticates to the correct project, and `kubectl set image` succeeds.
- [ ] Verify the new image rolls out on the `registry` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)