### PR TITLE
Run CI workflows on self-hosted runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Deploy
     steps:
     - uses: google-github-actions/auth@v1


### PR DESCRIPTION
## Summary
- Switch the Build and Deploy workflows from `ubuntu-latest` to `self-hosted` runners.

## Test plan
- [ ] Confirm a self-hosted runner is online and labeled `self-hosted` for the `deploys-app/registry` repo.
- [ ] After merge, verify the Build workflow picks up on the self-hosted runner and pushes the image.
- [ ] Verify the Deploy workflow runs on the self-hosted runner and updates the `registry` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)