### PR TITLE
Install kubectl in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,7 @@ jobs:
         project_id: ${{ vars.GKE_PROJECT }}
         cluster_name: ${{ vars.GKE_CLUSTER }}
         location: ${{ vars.GKE_LOCATION }}
+    - uses: azure/setup-kubectl@v4
     - name: Deploy
       env:
         IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/registry:${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary
- Add `azure/setup-kubectl@v4` after the GKE credentials step in `.github/workflows/deploy.yaml` so `kubectl` is available on the self-hosted runner before the `Deploy` step calls `kubectl set image`.

## Test plan
- [ ] Verify the Deploy workflow run completes successfully on the next push to `main` (the `kubectl set image` step finds the binary on PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)