### PR TITLE
Add /_cdn blob handler and optional CDN redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,4 +58,4 @@ HTTP → parapet (healthz, logger) → pgctx middleware (injects *sql.DB into ct
 
 **Context propagation** — long-running delete operations call `context.WithoutCancel(ctx)` so the deletion completes even if the HTTP client disconnects. The detached context still carries the pgctx DB connection.
 
-**CDN offload** — when `CDN_DOMAIN` is set, `getBlob` returns a 307 redirect to `https://{CDN_DOMAIN}/{name}/blobs/{digest}` instead of streaming the blob. The CDN domain is expected to proxy its root to the registry's `/_cdn/` path; the `/_cdn/` handler serves blobs unauthenticated (blobs are content-addressed by digest).
+**CDN offload** — when `CDN_DOMAIN` is set, `getBlob` returns a 307 redirect to `https://{CDN_DOMAIN}/{name}/blobs/{digest}` instead of streaming the blob. The CDN domain is expected to proxy its root to the registry's `/_cdn/` path; the `/_cdn/` handler serves blobs unauthenticated (blobs are content-addressed by digest). Internal callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly — this keeps in-cluster pulls off the public CDN path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Single-binary Go service (`package main`) — all files compile together with no
 HTTP → parapet (healthz, logger) → pgctx middleware (injects *sql.DB into ctx)
          ├── /v2/   → authMiddleware → registryHandler (OCI spec)
          ├── /api/  → apiAuthMiddleware → arpc router (management API)
+         ├── /_cdn/ → cdnHandler (unauthenticated blob origin for the CDN)
          └── /internal/  → internalAuth (Bearer token) → job handlers
 ```
 
@@ -56,3 +57,5 @@ HTTP → parapet (healthz, logger) → pgctx middleware (injects *sql.DB into ct
 **Auth caching** — `checkPermission` and `getEmail` cache results in `cachestore` (in-process, 30 s TTL) to avoid hammering `api.deploys.app` on every request.
 
 **Context propagation** — long-running delete operations call `context.WithoutCancel(ctx)` so the deletion completes even if the HTTP client disconnects. The detached context still carries the pgctx DB connection.
+
+**CDN offload** — when `CDN_DOMAIN` is set, `getBlob` returns a 307 redirect to `https://{CDN_DOMAIN}/{name}/blobs/{digest}` instead of streaming the blob. The CDN domain is expected to proxy its root to the registry's `/_cdn/` path; the `/_cdn/` handler serves blobs unauthenticated (blobs are content-addressed by digest).

--- a/main.go
+++ b/main.go
@@ -57,7 +57,10 @@ func main() {
 
 	bucket := storageClient.Bucket(config.MustString("bucket_name"))
 
-	app := &App{Bucket: bucket}
+	app := &App{
+		Bucket:    bucket,
+		CDNDomain: config.String("cdn_domain"),
+	}
 
 	internalSecret := config.String("internal_secret")
 
@@ -66,6 +69,7 @@ func main() {
 		w.Write([]byte("Deploys.app Registry Service"))
 	})
 	mux.Handle("/v2/", authMiddleware(http.HandlerFunc(app.registryHandler)))
+	mux.HandleFunc("/_cdn/", app.cdnHandler)
 	app.mountAPI(mux)
 	internalAuth := func(w http.ResponseWriter, r *http.Request) bool {
 		if internalSecret != "" && subtle.ConstantTimeCompare(

--- a/registry.go
+++ b/registry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -134,7 +135,7 @@ func (a *App) getBlob(w http.ResponseWriter, r *http.Request, name, digest strin
 		return
 	}
 
-	if a.CDNDomain != "" {
+	if a.CDNDomain != "" && !isInternalClient(r) {
 		if projectID := projectIDFromContext(ctx); projectID != "" {
 			downloadCount.WithLabelValues(projectID).Inc()
 			egressBytes.WithLabelValues(projectID).Add(float64(attrs.Size))
@@ -938,6 +939,17 @@ func registryError(w http.ResponseWriter, status int, code, message string) {
 	json.NewEncoder(w).Encode(registryErrorBody{
 		Errors: []registryErrorItem{{Code: code, Message: message, Detail: message}},
 	})
+}
+
+// isInternalClient returns true when the request originates from a
+// private/loopback/link-local IP per the X-Real-Ip header. Internal callers
+// (in-cluster pulls) bypass the CDN redirect and read blobs directly.
+func isInternalClient(r *http.Request) bool {
+	ip := net.ParseIP(r.Header.Get("X-Real-Ip"))
+	if ip == nil {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
 }
 
 func isNotFound(err error) bool {

--- a/registry.go
+++ b/registry.go
@@ -27,7 +27,8 @@ const chunkMinLength = 5 * 1024 * 1024 // 5 MiB
 
 // App holds shared dependencies.
 type App struct {
-	Bucket *storage.BucketHandle
+	Bucket    *storage.BucketHandle
+	CDNDomain string
 }
 
 var (
@@ -36,6 +37,7 @@ var (
 	reTags        = regexp.MustCompile(`^/v2/(.+)/tags/list$`)
 	reUploadStart = regexp.MustCompile(`^/v2/(.+)/blobs/uploads/?$`)
 	reUploadChunk = regexp.MustCompile(`^/v2/(.+)/blobs/uploads/([^/]+)$`)
+	reCDNBlob     = regexp.MustCompile(`^/_cdn/(.+)/blobs/(sha256:[a-f0-9]+)$`)
 )
 
 func (a *App) registryHandler(w http.ResponseWriter, r *http.Request) {
@@ -132,6 +134,16 @@ func (a *App) getBlob(w http.ResponseWriter, r *http.Request, name, digest strin
 		return
 	}
 
+	if a.CDNDomain != "" {
+		if projectID := projectIDFromContext(ctx); projectID != "" {
+			downloadCount.WithLabelValues(projectID).Inc()
+			egressBytes.WithLabelValues(projectID).Add(float64(attrs.Size))
+		}
+		w.Header().Set("Docker-Content-Digest", digest)
+		http.Redirect(w, r, "https://"+a.CDNDomain+"/"+name+"/blobs/"+digest, http.StatusTemporaryRedirect)
+		return
+	}
+
 	rc, err := obj.NewReader(ctx)
 	if err != nil {
 		registryError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
@@ -148,6 +160,50 @@ func (a *App) getBlob(w http.ResponseWriter, r *http.Request, name, digest strin
 		downloadCount.WithLabelValues(projectID).Inc()
 		egressBytes.WithLabelValues(projectID).Add(float64(n))
 	}
+}
+
+// cdnHandler serves blobs to the CDN edge. Unauthenticated — blobs are
+// content-addressed and only reachable if you know the digest.
+func (a *App) cdnHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	m := reCDNBlob.FindStringSubmatch(r.URL.Path)
+	if m == nil {
+		http.NotFound(w, r)
+		return
+	}
+	name, digest := m[1], m[2]
+	slog.Debug("cdn blob", "name", name, "digest", digest)
+
+	ctx := r.Context()
+	obj := a.Bucket.Object(fmt.Sprintf("%s/blobs/%s", name, digest))
+	attrs, err := obj.Attrs(ctx)
+	if isNotFound(err) {
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Docker-Content-Digest", digest)
+	w.Header().Set("Content-Length", strconv.FormatInt(attrs.Size, 10))
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	rc, err := obj.NewReader(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
+	io.Copy(w, rc)
 }
 
 // end-2 HEAD


### PR DESCRIPTION
## Summary
- New `/_cdn/{name}/blobs/{digest}` route serves blobs unauthenticated — intended as the origin for a CDN that proxies its root to this path. Blobs are content-addressed, so knowing the digest is the access control.
- New `CDN_DOMAIN` env var (read as `cdn_domain`). When set, `GET /v2/{name}/blobs/{digest}` returns a `307` redirect to `https://{CDN_DOMAIN}/{name}/blobs/{digest}` instead of streaming the blob. Existence check still runs first so an unknown blob returns the usual `BLOB_UNKNOWN` 404.
- Egress + download metrics are still incremented on the redirect path using `attrs.Size` (best-effort, since we no longer see the actual byte count).
- `HEAD /v2/{name}/blobs/{digest}` is unchanged (no redirect — clients use it as a cheap existence check).

## Test plan
- [ ] Build passes (`go build ./...`) — verified locally.
- [ ] Without `CDN_DOMAIN`: `GET /v2/{name}/blobs/{digest}` still streams blob bytes as before.
- [ ] With `CDN_DOMAIN=cdn.example.com`: `GET /v2/{name}/blobs/{digest}` returns 307 to `https://cdn.example.com/{name}/blobs/{digest}`; 404 still returned when the blob doesn't exist.
- [ ] `GET /_cdn/{name}/blobs/{digest}` returns the blob bytes without auth; non-existent digest → 404; non-GET/HEAD → 405.
- [ ] Configure the CDN to proxy its root to the registry's `/_cdn/` path before flipping `CDN_DOMAIN` on in production.

https://claude.ai/code/session_01E2RD4CFMBXK64mh6cgeb2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2RD4CFMBXK64mh6cgeb2F)_