### PR TITLE
Collapse concurrent auth lookups with a singleflight guard

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -8,12 +8,17 @@ import (
 	"time"
 
 	"github.com/moonrhythm/cachestore"
+	"github.com/moonrhythm/sf"
+)
+
+// Overridable in tests; production points at the real API.
+var (
+	authEndpoint = "https://api.deploys.app/me.authorized"
+	infoEndpoint = "https://api.deploys.app/me.get"
 )
 
 const (
-	authEndpoint = "https://api.deploys.app/me.authorized"
-	infoEndpoint = "https://api.deploys.app/me.get"
-	cacheTTL     = 30 * time.Second
+	cacheTTL = 30 * time.Second
 
 	permPull = "registry.pull"
 	permPush = "registry.push"
@@ -53,37 +58,51 @@ func apiAuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func getEmail(auth string) string {
+func getEmail(ctx context.Context, auth string) string {
 	cacheKey := "registry|email|" + auth
 	if v, ok := cachestore.Get[string](cacheKey); ok {
 		return v
 	}
 
-	req, _ := http.NewRequest(http.MethodPost, infoEndpoint, bytes.NewReader([]byte(`{}`)))
-	req.Header.Set("Authorization", auth)
-	req.Header.Set("Content-Type", "application/json")
+	// Collapse concurrent /v2/ pings carrying the same token into a single
+	// /me.get round-trip. The result is cached for 30s (cacheTTL); sf.Do
+	// dedupe matters at the cold-cache edge and right after that entry
+	// expires under load.
+	email, _, _ := sf.Do(ctx, cacheKey, func(ctx context.Context) (string, error) {
+		// Re-check the cache: a sibling caller may have populated it
+		// while we were queued behind sf's mutex.
+		if v, ok := cachestore.Get[string](cacheKey); ok {
+			return v, nil
+		}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return ""
-	}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, infoEndpoint, bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("Authorization", auth)
+		req.Header.Set("Content-Type", "application/json")
 
-	var res struct {
-		OK     bool `json:"ok"`
-		Result struct {
-			Email string `json:"email"`
-		} `json:"result"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil || !res.OK {
-		return ""
-	}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			// Don't cache transport failures — let the next caller retry.
+			return "", nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", nil
+		}
 
-	cachestore.Set(cacheKey, res.Result.Email, &cachestore.SetOptions{TTL: cacheTTL})
-	return res.Result.Email
+		var res struct {
+			OK     bool `json:"ok"`
+			Result struct {
+				Email string `json:"email"`
+			} `json:"result"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&res); err != nil || !res.OK {
+			return "", nil
+		}
+
+		cachestore.Set(cacheKey, res.Result.Email, &cachestore.SetOptions{TTL: cacheTTL})
+		return res.Result.Email, nil
+	})
+	return email
 }
 
 type permissionResult struct {
@@ -99,49 +118,63 @@ func checkPermissionWithID(ctx context.Context, project, permission string) perm
 		return v
 	}
 
-	body, _ := json.Marshal(map[string]any{
-		"project":     project,
-		"permissions": []string{permission},
-	})
-	req, _ := http.NewRequest(http.MethodPost, authEndpoint, bytes.NewReader(body))
-	if auth != "" {
-		req.Header.Set("Authorization", auth)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return permissionResult{}
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return permissionResult{}
-	}
-
-	var res struct {
-		OK     bool `json:"ok"`
-		Result struct {
-			Authorized bool `json:"authorized"`
-			Project    struct {
-				ID             string `json:"id"`
-				BillingAccount struct {
-					Active bool `json:"active"`
-				} `json:"billingAccount"`
-			} `json:"project"`
-		} `json:"result"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return permissionResult{}
-	}
-
-	var result permissionResult
-	if res.OK && res.Result.Authorized && res.Result.Project.BillingAccount.Active {
-		result = permissionResult{
-			OK:        true,
-			ProjectID: res.Result.Project.ID,
+	// Collapse a thundering herd of concurrent requests from the same
+	// caller into a single /me.authorized round-trip. The result is
+	// cached for 30s (cacheTTL); sf.Do dedupe matters at the cold-cache
+	// edge and right after that entry expires under load.
+	result, _, _ := sf.Do(ctx, cacheKey, func(ctx context.Context) (permissionResult, error) {
+		// Re-check the cache: a sibling caller may have populated it
+		// while we were queued behind sf's mutex.
+		if v, ok := cachestore.Get[permissionResult](cacheKey); ok {
+			return v, nil
 		}
-	}
-	cachestore.Set(cacheKey, result, &cachestore.SetOptions{TTL: cacheTTL})
+
+		body, _ := json.Marshal(map[string]any{
+			"project":     project,
+			"permissions": []string{permission},
+		})
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, authEndpoint, bytes.NewReader(body))
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			// Don't cache transport failures — let the next caller retry.
+			return permissionResult{}, nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return permissionResult{}, nil
+		}
+
+		var res struct {
+			OK     bool `json:"ok"`
+			Result struct {
+				Authorized bool `json:"authorized"`
+				Project    struct {
+					ID             string `json:"id"`
+					BillingAccount struct {
+						Active bool `json:"active"`
+					} `json:"billingAccount"`
+				} `json:"project"`
+			} `json:"result"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+			return permissionResult{}, nil
+		}
+
+		var result permissionResult
+		if res.OK && res.Result.Authorized && res.Result.Project.BillingAccount.Active {
+			result = permissionResult{
+				OK:        true,
+				ProjectID: res.Result.Project.ID,
+			}
+		}
+		cachestore.Set(cacheKey, result, &cachestore.SetOptions{TTL: cacheTTL})
+		return result, nil
+	})
 	return result
 }
 
@@ -161,7 +194,7 @@ func authMiddleware(next http.Handler) http.Handler {
 
 		path := r.URL.Path
 		if path == "/v2/" {
-			if auth != "" && getEmail(auth) == "" {
+			if auth != "" && getEmail(ctx, auth) == "" {
 				registryUnauthorized(w, r)
 				return
 			}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A single mock server is started lazily and serves every auth test. It
+// routes by request path (/me.authorized vs /me.get) and by Authorization
+// header so parallel tests don't race over the package-level endpoint vars
+// or trample each other's cachestore entries (cache keys include the token).
+var (
+	authMockOnce sync.Once
+	authMockMap  sync.Map // token -> http.HandlerFunc
+)
+
+func setupAuthMock() {
+	authMockOnce.Do(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if h, ok := authMockMap.Load(r.Header.Get("Authorization")); ok {
+				h.(http.HandlerFunc)(w, r)
+				return
+			}
+			http.Error(w, "no mock registered for token", http.StatusNotFound)
+		}))
+		authEndpoint = srv.URL + "/me.authorized"
+		infoEndpoint = srv.URL + "/me.get"
+	})
+}
+
+func registerAuthMock(t *testing.T, token string, h http.HandlerFunc) {
+	t.Helper()
+	setupAuthMock()
+	authMockMap.Store(token, h)
+	t.Cleanup(func() { authMockMap.Delete(token) })
+}
+
+// jsonAuthorized responds with the standard /me.authorized envelope.
+func jsonAuthorized(authorized, billingActive bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"result": map[string]any{
+				"authorized": authorized,
+				"project": map[string]any{
+					"id": "proj-123",
+					"billingAccount": map[string]any{
+						"active": billingActive,
+					},
+				},
+			},
+		})
+	}
+}
+
+// jsonEmail responds with the standard /me.get envelope.
+func jsonEmail(email string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"result": map[string]any{"email": email},
+		})
+	}
+}
+
+func ctxWithAuth(token string) context.Context {
+	return context.WithValue(context.Background(), authKey, token)
+}
+
+func TestCheckPermission_Authorized(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, jsonAuthorized(true, true))
+
+	res := checkPermissionWithID(ctxWithAuth(token), "myproject", permPull)
+	if !res.OK {
+		t.Fatal("expected authorized")
+	}
+	if res.ProjectID != "proj-123" {
+		t.Errorf("project ID = %q, want proj-123", res.ProjectID)
+	}
+}
+
+func TestCheckPermission_NotAuthorized(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, jsonAuthorized(false, true))
+
+	if checkPermissionWithID(ctxWithAuth(token), "myproject", permPull).OK {
+		t.Error("expected unauthorized when API returns authorized=false")
+	}
+}
+
+func TestCheckPermission_BillingInactive(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, jsonAuthorized(true, false))
+
+	if checkPermissionWithID(ctxWithAuth(token), "myproject", permPull).OK {
+		t.Error("expected unauthorized when billing is inactive")
+	}
+}
+
+func TestCheckPermission_API500(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	if checkPermissionWithID(ctxWithAuth(token), "myproject", permPull).OK {
+		t.Error("expected unauthorized when auth API returns 500")
+	}
+}
+
+func TestCheckPermission_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	})
+
+	if checkPermissionWithID(ctxWithAuth(token), "myproject", permPull).OK {
+		t.Error("expected unauthorized when auth API returns invalid JSON")
+	}
+}
+
+func TestCheckPermission_CachesResult(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		jsonAuthorized(true, true)(w, r)
+	})
+
+	ctx := ctxWithAuth(token)
+	checkPermissionWithID(ctx, "myproject", permPull)
+	checkPermissionWithID(ctx, "myproject", permPull)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("auth API called %d times, want 1 (should be cached)", got)
+	}
+}
+
+func TestCheckPermission_CacheKeyDistinguishesPermissions(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		jsonAuthorized(true, true)(w, r)
+	})
+
+	ctx := ctxWithAuth(token)
+	checkPermissionWithID(ctx, "myproject", permPush)
+	checkPermissionWithID(ctx, "myproject", permPull)
+	checkPermissionWithID(ctx, "myproject", permPush) // cached
+	checkPermissionWithID(ctx, "myproject", permPull) // cached
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("auth API called %d times, want 2 (one per distinct permission)", got)
+	}
+}
+
+func TestCheckPermission_SingleflightCollapsesConcurrentCalls(t *testing.T) {
+	// 50 goroutines race on a cold-cache (auth, project, permission)
+	// triple. sf.Do must collapse them into a single /me.authorized
+	// round-trip — otherwise a burst of concurrent pulls/pushes from one
+	// caller (e.g. a parallel CI matrix pulling the same image) hammers
+	// the deploys.app API on every cache-miss edge.
+	t.Parallel()
+	var calls atomic.Int64
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		// A short sleep widens the singleflight window so the test
+		// reliably catches a regression where dedupe is broken.
+		time.Sleep(50 * time.Millisecond)
+		jsonAuthorized(true, true)(w, r)
+	})
+
+	const N = 50
+	ctx := ctxWithAuth(token)
+	results := make([]permissionResult, N)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx] = checkPermissionWithID(ctx, "sfproject", permPull)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, r := range results {
+		if !r.OK {
+			t.Errorf("results[%d] not authorized", i)
+		}
+	}
+	if got := calls.Load(); got >= N {
+		t.Errorf("auth API called %d times, want <%d (sf should have collapsed the herd)", got, N)
+	}
+}
+
+func TestGetEmail_ReturnsEmail(t *testing.T) {
+	t.Parallel()
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, jsonEmail("user@example.com"))
+
+	if got := getEmail(context.Background(), token); got != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", got)
+	}
+}
+
+func TestGetEmail_CachesResult(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		jsonEmail("user@example.com")(w, r)
+	})
+
+	getEmail(context.Background(), token)
+	getEmail(context.Background(), token)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("info API called %d times, want 1 (should be cached)", got)
+	}
+}
+
+func TestGetEmail_SingleflightCollapsesConcurrentCalls(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	token := "Bearer " + t.Name()
+	registerAuthMock(t, token, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		jsonEmail("user@example.com")(w, r)
+	})
+
+	const N = 50
+	emails := make([]string, N)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			emails[idx] = getEmail(context.Background(), token)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, e := range emails {
+		if e != "user@example.com" {
+			t.Errorf("emails[%d] = %q, want user@example.com", i, e)
+		}
+	}
+	if got := calls.Load(); got >= N {
+		t.Errorf("info API called %d times, want <%d (sf should have collapsed the herd)", got, N)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/moonrhythm/cachestore v0.0.0-20241226112208-fd22884c5b60
 	github.com/moonrhythm/parapet v0.13.6
+	github.com/moonrhythm/sf v1.0.2
 	github.com/prometheus/client_golang v1.20.5
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.274.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/moonrhythm/parapet v0.13.6 h1:xpoXIEI1JiNVTs8F2edmZn75gMV2Dg6KQdpOlUt
 github.com/moonrhythm/parapet v0.13.6/go.mod h1:QEhl1pk8viGxC3xz1XLmzU8UZRT5qxHXgUln5hXlRCQ=
 github.com/moonrhythm/pq v0.0.0-20230504040008-09b0644d6569 h1:VDLLIg19HS2A7HuMY8ukFNrdgrRqGn5O0xQ4zrSgD/0=
 github.com/moonrhythm/pq v0.0.0-20230504040008-09b0644d6569/go.mod h1:V43Namo2SgpLTmiaQXjiKPuKvqGamIhPawsQF+pv8xw=
+github.com/moonrhythm/sf v1.0.2 h1:W7uHinFjiO1A+7UNDANka78J9jk1nQz+W7IzK0bpj68=
+github.com/moonrhythm/sf v1.0.2/go.mod h1:GVFIuH7VwfIn+wVi+kcjxAUcFsQ2JmiUrQuIg5yuono=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
## What

Wrap the cache-miss paths of `checkPermissionWithID` (`/me.authorized`) and `getEmail` (`/me.get`) in a `github.com/moonrhythm/sf` singleflight guard so concurrent requests for the same key collapse into a single round-trip to `api.deploys.app`.

## Why

Both functions already cache their result in `cachestore` with a 30s TTL, but the cache only helps *after* the first response lands. On a cache miss — cold start, or the moment a 30s entry expires under load — every concurrent request fired its own backend call. A burst of pulls/pushes from one caller (e.g. a parallel CI matrix pulling the same image under one token) becomes a thundering herd against the deploys.app API on every cache-miss edge. `authMiddleware` makes this worse: a single push request can call `checkPermissionWithID` twice (push then pull fallback).

This mirrors the singleflight guard added to the dropbox service.

## How

- `sf.Do(ctx, cacheKey, ...)` around each cache-miss backend call, keyed by the same cache key already in use.
- A cache re-check inside the closure: a sibling caller may have populated the entry while we were queued behind sf's mutex.
- Transport failures and non-200s are **not** cached — the next caller retries (unchanged behavior, now inside the closure).
- Requests are threaded with the caller's context (`http.NewRequestWithContext`).
- `getEmail` gained a `ctx` parameter (its one caller, `authMiddleware`, already has one).
- `authEndpoint` / `infoEndpoint` moved from `const` to package `var` so tests can point them at an `httptest` server.

## Tests

This repo previously had no tests. Added `auth_test.go` (httptest-backed, no DB/network) covering both helpers:

- authorized / not-authorized / billing-inactive / 500 / invalid-JSON outcomes
- result caching (one backend call for repeat lookups)
- cache key distinguishes permission (and token)
- **singleflight collapse**: 50 goroutines racing a cold-cache key issue `< 50` backend calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)