### PR TITLE
Add internal GCS-cleanup endpoints for the management API

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/acoshift/arpc/v2"
 	"github.com/acoshift/pgsql"
 	"github.com/acoshift/pgsql/pgctx"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/api/iterator"
 )
 
 func (a *App) mountAPI(mux *http.ServeMux) {
@@ -363,21 +359,8 @@ func (a *App) apiDelete(ctx context.Context, req *apiDeleteRequest) error {
 	dctx := context.WithoutCancel(ctx)
 
 	// Delete all GCS objects under this repository prefix
-	it := a.Bucket.Objects(dctx, &storage.Query{
-		Prefix:     fullName + "/",
-		Projection: storage.ProjectionNoACL,
-	})
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if err := a.Bucket.Object(attrs.Name).Delete(dctx); err != nil && !isNotFound(err) {
-			return err
-		}
+	if err := a.deleteRepositoryObjects(dctx, fullName); err != nil {
+		return err
 	}
 
 	// Delete DB records in FK dependency order
@@ -452,26 +435,8 @@ func (a *App) apiDeleteManifest(ctx context.Context, req *apiDeleteManifestReque
 		return err
 	}
 
-	// Delete GCS objects (digest-addressed manifest + all tag-addressed manifests) in parallel.
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, req.Digest))
-		if err := obj.Delete(gctx); err != nil && !isNotFound(err) {
-			return err
-		}
-		return nil
-	})
-	for _, tag := range tags {
-		tag := tag
-		g.Go(func() error {
-			obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, tag))
-			if err := obj.Delete(gctx); err != nil && !isNotFound(err) {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
+	// Delete GCS objects (digest-addressed manifest + all tag-addressed manifests).
+	if err := a.deleteManifestObjects(ctx, fullName, req.Digest, tags); err != nil {
 		return err
 	}
 
@@ -528,8 +493,7 @@ func (a *App) apiUntag(ctx context.Context, req *apiUntagRequest) error {
 	}
 
 	// Delete the tag-named GCS object (best-effort; ignore if already gone)
-	obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, req.Tag))
-	if err := obj.Delete(ctx); err != nil && !isNotFound(err) {
+	if err := a.deleteTagObject(ctx, fullName, req.Tag); err != nil {
 		return err
 	}
 

--- a/internal_gcs.go
+++ b/internal_gcs.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+)
+
+// GCS-object cleanup for the registry management API. The management API itself
+// now lives in the apiserver (which owns the registry.* tables): it deletes the
+// DB rows and calls these internal endpoints to remove the corresponding GCS
+// objects, so the bucket credentials stay in the registry service.
+
+// deleteRepositoryObjects removes every GCS object under the repository prefix
+// "{fullName}/" (fullName is the full "{namespace}/{repo}" name).
+func (a *App) deleteRepositoryObjects(ctx context.Context, fullName string) error {
+	it := a.Bucket.Objects(ctx, &storage.Query{
+		Prefix:     fullName + "/",
+		Projection: storage.ProjectionNoACL,
+	})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := a.Bucket.Object(attrs.Name).Delete(ctx); err != nil && !isNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteManifestObjects removes the digest-addressed manifest object plus each
+// tag-addressed manifest object, in parallel.
+func (a *App) deleteManifestObjects(ctx context.Context, fullName, digest string, tags []string) error {
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, digest))
+		if err := obj.Delete(gctx); err != nil && !isNotFound(err) {
+			return err
+		}
+		return nil
+	})
+	for _, tag := range tags {
+		tag := tag
+		g.Go(func() error {
+			obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, tag))
+			if err := obj.Delete(gctx); err != nil && !isNotFound(err) {
+				return err
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// deleteTagObject removes the tag-addressed manifest object (best-effort).
+func (a *App) deleteTagObject(ctx context.Context, fullName, tag string) error {
+	obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, tag))
+	if err := obj.Delete(ctx); err != nil && !isNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// mountInternalGCS registers the internal GCS-cleanup endpoints the apiserver
+// calls after it has deleted the registry rows. Protected by internalAuth.
+func (a *App) mountInternalGCS(mux *http.ServeMux, internalAuth func(http.ResponseWriter, *http.Request) bool) {
+	mux.HandleFunc("POST /internal/registry/deleteRepository", func(w http.ResponseWriter, r *http.Request) {
+		if !internalAuth(w, r) {
+			return
+		}
+		var req struct {
+			Repository string `json:"repository"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Detach so a large prefix delete completes even if the caller drops.
+		if err := a.deleteRepositoryObjects(context.WithoutCancel(r.Context()), req.Repository); err != nil {
+			slog.Error("deleteRepositoryObjects", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("POST /internal/registry/deleteManifest", func(w http.ResponseWriter, r *http.Request) {
+		if !internalAuth(w, r) {
+			return
+		}
+		var req struct {
+			Repository string   `json:"repository"`
+			Digest     string   `json:"digest"`
+			Tags       []string `json:"tags"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := a.deleteManifestObjects(r.Context(), req.Repository, req.Digest, req.Tags); err != nil {
+			slog.Error("deleteManifestObjects", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("POST /internal/registry/untag", func(w http.ResponseWriter, r *http.Request) {
+		if !internalAuth(w, r) {
+			return
+		}
+		var req struct {
+			Repository string `json:"repository"`
+			Tag        string `json:"tag"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := a.deleteTagObject(r.Context(), req.Repository, req.Tag); err != nil {
+			slog.Error("deleteTagObject", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
+	app.mountInternalGCS(mux, internalAuth)
 
 	promAddr := config.StringDefault("prom_addr", ":9187")
 	go func() {


### PR DESCRIPTION
## What

The registry **management API** (`/api/*`) is moving to the apiserver (which now owns the `registry.*` tables in the shared cluster). The apiserver will delete the DB rows itself and call these new internal endpoints to remove the corresponding **GCS objects** — so the bucket credentials stay in the registry service.

New internal endpoints (bearer `INTERNAL_SECRET`, like the existing `/internal/*` jobs):
- `POST /internal/registry/deleteRepository` `{repository}` → delete all objects under `{repository}/`.
- `POST /internal/registry/deleteManifest` `{repository, digest, tags[]}` → delete the manifest + tag objects.
- `POST /internal/registry/untag` `{repository, tag}` → delete the tag object.

(`repository` is the full `{namespace}/{repo}` name.)

The GCS-deletion logic is extracted into shared `App` methods (`internal_gcs.go`); the current `/api/delete` / `/api/deleteManifest` / `/api/untag` handlers now reuse them — no behavior change.

## Scope / sequencing

Purely **additive** — `/api/*` still works. It gets removed in a follow-up **after** the console cuts over to the apiserver-served `registry.*` RPCs, to avoid a gap. `/v2/`, `/_cdn/`, and the GC/index jobs are untouched.

## Related
- deploys-app/api#29 — completes the Registry contract
- apiserver PR (next) — serves `registry.*` and calls these endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)