### PR TITLE
chore: modernize to Go 1.26 idioms

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -191,7 +191,7 @@ func TestCheckPermission_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	results := make([]permissionResult, N)
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -253,7 +253,7 @@ func TestGetEmail_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	emails := make([]string, N)
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()

--- a/internal_gcs.go
+++ b/internal_gcs.go
@@ -51,7 +51,6 @@ func (a *App) deleteManifestObjects(ctx context.Context, fullName, digest string
 		return nil
 	})
 	for _, tag := range tags {
-		tag := tag
 		g.Go(func() error {
 			obj := a.Bucket.Object(fmt.Sprintf("%s/manifests/%s", fullName, tag))
 			if err := obj.Delete(gctx); err != nil && !isNotFound(err) {

--- a/migrate/d1topg/main.go
+++ b/migrate/d1topg/main.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/lib/pq"
 	"github.com/acoshift/pgsql/pgstmt"
+	_ "github.com/lib/pq"
 )
 
 const (

--- a/registry.go
+++ b/registry.go
@@ -362,10 +362,7 @@ func (a *App) startUpload(w http.ResponseWriter, r *http.Request, name string) {
 				return
 			}
 			if projectID != "" {
-				size := r.ContentLength
-				if size < 0 {
-					size = 0
-				}
+				size := max(r.ContentLength, 0)
 				uploadCount.WithLabelValues(projectID).Inc()
 				uploadBytes.WithLabelValues(projectID).Add(float64(size))
 			}
@@ -439,10 +436,7 @@ func (a *App) patchUpload(w http.ResponseWriter, r *http.Request, name, referenc
 		slog.Debug("patch upload empty chunk ignored", "name", name, "reference", reference)
 	}
 
-	end := state.Size - 1
-	if end < 0 {
-		end = 0
-	}
+	end := max(state.Size-1, 0)
 	w.Header().Set("Location", uploadLocation(name, reference, state))
 	w.Header().Set("Range", fmt.Sprintf("0-%d", end))
 	w.WriteHeader(http.StatusAccepted)
@@ -758,10 +752,7 @@ func (a *App) composeParts(ctx context.Context, reference string, partCount int,
 	for len(srcs) > maxCompose {
 		var next []*storage.ObjectHandle
 		for i := 0; i < len(srcs); i += maxCompose {
-			end := i + maxCompose
-			if end > len(srcs) {
-				end = len(srcs)
-			}
+			end := min(i+maxCompose, len(srcs))
 			batch := srcs[i:end]
 			stageDst := a.Bucket.Object(fmt.Sprintf("_uploads/%s/stage-%d-%d", reference, stage, len(next)))
 			stageTempObjects = append(stageTempObjects, stageDst)


### PR DESCRIPTION
## What

Behavior-preserving modernization to Go 1.26 idioms, applied with the official `modernize` analyzer from `golang.org/x/tools` (version-aware against this module's `go` directive).

### Changes
- Replace `if x < 0 { x = 0 }` / `if x > n { x = n }` clamp blocks with `min()`/`max()` builtins (Go 1.21)
- Convert `for i := 0; i < N; i++` counter loops to `for i := range N` (Go 1.22)
- Remove redundant `tag := tag` loop-variable captures (per-iteration loop vars since Go 1.22)

### Safety
- **No functional change** — all transformations are behavior-preserving.
- `omitempty`→`omitzero` JSON-tag rewrites were **deliberately excluded** (they can change wire output).
- `go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)