### PR TITLE
registry: test extractProject / isPushRequest auth helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build
 go build ./...
 
+# Test (the auth helpers / permission caching have unit tests; most of the
+# OCI + storage paths still need a real PostgreSQL and GCS bucket and are
+# uncovered)
+go test ./...
+
 # Run locally (requires a real PostgreSQL and GCS bucket)
 DB_URL=postgres://user:pass@host/db BUCKET_NAME=my-bucket go run .
 
@@ -15,7 +20,7 @@ DB_URL=postgres://user:pass@host/db BUCKET_NAME=my-bucket go run .
 psql $DB_URL -f schema.sql
 ```
 
-There are no tests in this repository. CI only builds and pushes a Docker image on push to `main`.
+CI builds and pushes a Docker image on push to `main`; it does not run the tests.
 
 ## Architecture
 

--- a/auth_helpers_test.go
+++ b/auth_helpers_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestExtractProject pins the project-scoping parser: it returns the first path
+// segment after /v2/ (the project namespace the request's permissions are
+// checked against), and "" when there is no namespace+repo to scope to.
+func TestExtractProject(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v2/acme/web/manifests/latest", "acme"},
+		{"/v2/acme/web/blobs/sha256:abc", "acme"},
+		{"/v2/acme/web/tags/list", "acme"},
+		{"/v2/acme/team/web/manifests/latest", "acme"}, // only the first segment
+		// No namespace+repo to scope to.
+		{"/v2/acme", ""}, // bare namespace, no repo path
+		{"/v2/", ""},
+		{"/v2", ""},
+		{"/v2/_catalog", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := extractProject(tc.path); got != tc.want {
+			t.Errorf("extractProject(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestIsPushRequest pins the read/write split that gates the registry.push
+// permission: GET/HEAD are pulls (read); every other method (PUT/POST/PATCH/
+// DELETE) is a push and requires write access.
+func TestIsPushRequest(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{http.MethodGet, false},
+		{http.MethodHead, false},
+		{http.MethodPut, true},
+		{http.MethodPost, true},
+		{http.MethodPatch, true},
+		{http.MethodDelete, true},
+	}
+	for _, tc := range tests {
+		if got := isPushRequest(tc.method); got != tc.want {
+			t.Errorf("isPushRequest(%q) = %v, want %v", tc.method, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `auth_helpers_test.go` for two pure, **security-relevant** helpers in `auth.go` that had no coverage:

- **`extractProject(path)`** — the project namespace a request is scoped to: the first segment after `/v2/`, or `""` when there's no namespace+repo (bare `/v2/ns`, `/v2/`, `_catalog`). This decides *which project's* permissions get checked, so a regression would scope the check to the wrong (or no) project.
- **`isPushRequest(method)`** — the read/write split that gates the `registry.push` permission: `GET`/`HEAD` are pulls, everything else (`PUT`/`POST`/`PATCH`/`DELETE`) is a push.

Table tests pin both, including the first-segment-only case (`/v2/acme/team/web/...` → `acme`) and the bare-namespace → `""` case.

Also corrects `CLAUDE.md`, which claimed "There are no tests in this repository" — `auth_test.go` and `registry_manifest_test.go` already exist; CI just doesn't run them (it only builds and pushes the image).

## Why

These two helpers sit directly on the auth path (project scoping + write-permission gate) but were untested, and the repo's own guidance said there were no tests at all.

## Verification

- `go test ./...` green (14 tests); `go vet` and `gofmt` clean.
- Pure helpers — no PostgreSQL/GCS needed.
- Expected values traced against `extractProject`/`isPushRequest`. Test + doc only; no production code changed.

## Note (existing behavior, not changed)

`extractProject` returns `""` for a bare `/v2/{namespace}` (no repo path) — fine, since that's not a real OCI operation and an empty project scope is fail-closed. It also assumes the `/v2/` prefix, which the router guarantees (the handler is only mounted there).