### PR TITLE
fix(registry): close mount-origin response body on non-200 status

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -325,8 +325,10 @@ func (a *App) startUpload(w http.ResponseWriter, r *http.Request, name string) {
 
 		if origin != "" {
 			resp, err := http.Get("https://" + origin + "/v2/" + from + "/blobs/" + mount)
-			if err == nil && resp.StatusCode == http.StatusOK {
+			if err == nil {
 				defer resp.Body.Close()
+			}
+			if err == nil && resp.StatusCode == http.StatusOK {
 				size, _ := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
 				if err := a.writeBlob(ctx, name, mount, resp.Body); err == nil {
 					if err := a.insertBlob(ctx, name, mount, size); err != nil {


### PR DESCRIPTION
## What

In `startUpload`'s cross-repo blob-mount path (`origin != ""`), the origin fetch closed its response body only inside the `200 OK` branch:

```go
resp, err := http.Get("https://" + origin + "/v2/" + from + "/blobs/" + mount)
if err == nil && resp.StatusCode == http.StatusOK {
    defer resp.Body.Close()
    ...
}
```

When `http.Get` **succeeded** (`err == nil`) but the origin returned a **non-200** status, the whole block — including the `defer Close` — was skipped, so the body was never closed. `http.Get` returns a non-nil `resp` with an open body even on non-2xx, so this leaked a response body / connection on every such mount attempt.

## Fix

Register the close as soon as `err == nil`, before the status check:

```go
resp, err := http.Get(...)
if err == nil {
    defer resp.Body.Close()
}
if err == nil && resp.StatusCode == http.StatusOK {
    ...
}
```

- Closes the body on both the 200 and non-200 paths (at function return).
- No nil-deref: when `err != nil`, `http.Get` returns a nil `resp` and the `if err == nil` guard skips it (and the later `&&` short-circuits).
- Behavior otherwise unchanged: the success path still streams `resp.Body` to `writeBlob` and closes at return.

## Verification

- `go build ./...` ok; `go vet` clean; `gofmt` clean.
- registry has no tests for this OCI/storage path (needs a real GCS bucket + remote origin), so this is a minimal, build-verified defer-placement fix.

## Not in this PR

There's a separate temp-object-leak-on-error in `composeParts` (staged compose parts aren't cleaned up when a compose call fails). I left it out deliberately: cleaning up part objects on error interacts with OCI upload-retry semantics that can't be verified without tests, so it warrants a separate, more careful change.