### PR TITLE
fix: protect live multi-arch image blobs from GC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Single-binary Go service (`package main`) — all files compile together with no
 | `registry.go` | OCI Distribution Spec v1 implementation (`/v2/` routes) including chunked blob upload via GCS compose |
 | `api.go` | Management API (`/api/` routes) using arpc |
 | `auth.go` | Auth middleware + `checkPermission` / `getEmail` helpers that delegate to `api.deploys.app` with 30 s in-memory caching |
-| `gc.go` | `runBlobGC` — deletes unreferenced blobs older than 1 day |
+| `gc.go` | `runBlobGC` — deletes unreferenced blobs older than 1 day (skips repos with unindexed manifests) |
 | `storage_usage.go` | `calculateProjectStorage` — aggregates blob sizes per project namespace |
 | `errors.go` | Shared `arpc.NewError` values (`errForbidden`, `errRepoNotFound`, etc.) |
 | `schema.sql` | PostgreSQL schema (apply manually; no migration tool) |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ psql $DB_URL -f schema.sql
 | `tags` | Tag → manifest digest mappings |
 | `blobs` | Blob metadata including size |
 | `manifest_blobs` | Manifest → blob references (rebuilt by `indexManifests`) |
+| `manifest_children` | Image index → child manifest digests (for multi-arch GC keep-set expansion) |
 | `project_storage_usage` | Pre-calculated total blob storage per project namespace (updated by `calculateProjectStorage`) |
 
 ## API
@@ -255,7 +256,7 @@ Requires `registry.push` permission.
 
 ### `POST /internal/indexManifests`
 
-Reads every manifest that has no `manifest_blobs` rows yet, fetches its content from GCS, and records which blobs it references. Runs as part of `POST /internal/runAll`.
+Reads every unindexed manifest (size still null) and any sized image index missing `manifest_children` rows, fetches content from GCS, and records blob refs (image manifests) or child-manifest digests (image indexes). Runs as part of `POST /internal/runAll`.
 
 Protected by `Authorization: Bearer <INTERNAL_SECRET>`. If `INTERNAL_SECRET` is not set the check is skipped (local dev only).
 
@@ -270,7 +271,7 @@ curl -X POST https://registry.deploys.app/internal/indexManifests \
 
 ### `POST /internal/runBlobGC`
 
-Deletes blobs that are not referenced by any manifest and are older than 1 day. The 1-day grace period covers blobs that have been uploaded but whose manifest push is still in flight. Runs as part of `POST /internal/runAll`.
+Deletes blobs that are not referenced by any manifest and are older than 1 day. The 1-day grace period covers blobs that have been uploaded but whose manifest push is still in flight. Repositories that still have unindexed manifests (`size is null`) are skipped so incomplete indexing cannot orphan a live image's layers. Runs as part of `POST /internal/runAll`.
 
 Returns `204 No Content` on success. Protected by the same `INTERNAL_SECRET` bearer token.
 

--- a/gc.go
+++ b/gc.go
@@ -15,9 +15,47 @@ import (
 //
 // Blobs in a repository that still has unindexed manifests (size is null) are
 // skipped: indexing may still be writing their manifest_blobs rows, and
-// deleting would break a live (or soon-to-be-indexed) image.
+// deleting would break a live (or soon-to-be-indexed) image. A permanently
+// size-null manifest (lost GCS body, unparseable) blocks that repo forever by
+// design — prefer a stuck leak over reclaiming live layers; skipped repos are
+// logged so the stuck state is visible.
+//
+// Ordering: the DB row is deleted first (with an unreferenced re-check), then
+// the GCS object. The reverse order could leave a live digest with no object.
+// There remains a narrow race where a re-upload of the same digest between the
+// two steps can lose the fresh object while the new row remains; that class
+// predates this change and is not closed here.
 func (a *App) runBlobGC(ctx context.Context) error {
 	slog.Info("blob gc: start")
+
+	// Surface repos that will be entirely skipped by the unindexed guard so a
+	// permanently stuck size-null manifest is not silent storage growth.
+	type skipRepo struct {
+		repository string
+		nullCount  int64
+	}
+	var skipped []skipRepo
+	err := pgctx.Iter(ctx, func(scan pgsql.Scanner) error {
+		var s skipRepo
+		if err := scan(&s.repository, &s.nullCount); err != nil {
+			return err
+		}
+		skipped = append(skipped, s)
+		return nil
+	}, `
+		select m.repository, count(*)
+		from manifests m
+		where m.size is null
+		group by m.repository
+		order by m.repository
+	`)
+	if err != nil {
+		return fmt.Errorf("blob gc: query unindexed repos: %w", err)
+	}
+	for _, s := range skipped {
+		slog.Warn("blob gc: skipping repository with unindexed manifests",
+			"repository", s.repository, "size_null_count", s.nullCount)
+	}
 
 	type blobRef struct {
 		repository string
@@ -25,7 +63,7 @@ func (a *App) runBlobGC(ctx context.Context) error {
 	}
 
 	var unreferenced []blobRef
-	err := pgctx.Iter(ctx, func(scan pgsql.Scanner) error {
+	err = pgctx.Iter(ctx, func(scan pgsql.Scanner) error {
 		var ref blobRef
 		if err := scan(&ref.repository, &ref.digest); err != nil {
 			return err
@@ -52,11 +90,11 @@ func (a *App) runBlobGC(ctx context.Context) error {
 	}
 
 	if len(unreferenced) == 0 {
-		slog.Info("blob gc: no unreferenced blobs found")
+		slog.Info("blob gc: no unreferenced blobs found", "skipped_repos", len(skipped))
 		return nil
 	}
 
-	slog.Info("blob gc: found unreferenced blobs", "count", len(unreferenced))
+	slog.Info("blob gc: found unreferenced blobs", "count", len(unreferenced), "skipped_repos", len(skipped))
 	deleted := 0
 	for _, ref := range unreferenced {
 		// Delete the DB row first, re-checking that it is still unreferenced so a
@@ -88,6 +126,6 @@ func (a *App) runBlobGC(ctx context.Context) error {
 		}
 		deleted++
 	}
-	slog.Info("blob gc: complete", "deleted", deleted, "total", len(unreferenced))
+	slog.Info("blob gc: complete", "deleted", deleted, "total", len(unreferenced), "skipped_repos", len(skipped))
 	return nil
 }

--- a/gc.go
+++ b/gc.go
@@ -12,6 +12,10 @@ import (
 // runBlobGC deletes blobs that are not referenced by any manifest and are
 // older than 1 day (grace period for in-flight manifest pushes that have
 // uploaded blobs but not yet pushed the manifest).
+//
+// Blobs in a repository that still has unindexed manifests (size is null) are
+// skipped: indexing may still be writing their manifest_blobs rows, and
+// deleting would break a live (or soon-to-be-indexed) image.
 func (a *App) runBlobGC(ctx context.Context) error {
 	slog.Info("blob gc: start")
 
@@ -37,6 +41,11 @@ func (a *App) runBlobGC(ctx context.Context) error {
 		      where mb.repository = b.repository
 		        and mb.blob_digest = b.digest
 		  )
+		  and not exists (
+		      select 1 from manifests m
+		      where m.repository = b.repository
+		        and m.size is null
+		  )
 	`)
 	if err != nil {
 		return fmt.Errorf("blob gc: query unreferenced blobs: %w", err)
@@ -50,16 +59,32 @@ func (a *App) runBlobGC(ctx context.Context) error {
 	slog.Info("blob gc: found unreferenced blobs", "count", len(unreferenced))
 	deleted := 0
 	for _, ref := range unreferenced {
+		// Delete the DB row first, re-checking that it is still unreferenced so a
+		// concurrent index/push cannot lose a now-live blob. Only then remove
+		// the GCS object (orphaned objects are cheaper than a live digest with
+		// no object).
+		res, err := pgctx.Exec(ctx, `
+			delete from blobs b
+			where b.repository = $1 and b.digest = $2
+			  and not exists (
+			      select 1 from manifest_blobs mb
+			      where mb.repository = b.repository
+			        and mb.blob_digest = b.digest
+			  )
+		`, ref.repository, ref.digest)
+		if err != nil {
+			slog.Warn("blob gc: delete db record", "repository", ref.repository, "digest", ref.digest, "error", err)
+			continue
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			continue
+		}
 		obj := a.Bucket.Object(fmt.Sprintf("%s/blobs/%s", ref.repository, ref.digest))
 		if err := obj.Delete(ctx); err != nil && !isNotFound(err) {
 			slog.Warn("blob gc: delete gcs object", "repository", ref.repository, "digest", ref.digest, "error", err)
-			continue
-		}
-		if _, err := pgctx.Exec(ctx, `
-			delete from blobs where repository = $1 and digest = $2
-		`, ref.repository, ref.digest); err != nil {
-			slog.Warn("blob gc: delete db record", "repository", ref.repository, "digest", ref.digest, "error", err)
-			continue
+			// DB row is already gone; leave the object for a later sweep or
+			// accept orphan storage rather than resurrecting an unreferenced row.
 		}
 		deleted++
 	}

--- a/registry.go
+++ b/registry.go
@@ -692,6 +692,7 @@ func (a *App) deleteManifest(w http.ResponseWriter, r *http.Request, name, refer
 		// Delete dependent rows before manifests (FK constraints have no CASCADE).
 		for _, q := range []string{
 			`delete from manifest_blobs where repository = $1 and manifest_digest = $2`,
+			`delete from manifest_children where repository = $1 and (parent_digest = $2 or child_digest = $2)`,
 			`delete from tags            where repository = $1 and digest         = $2`,
 			`delete from manifests       where repository = $1 and digest         = $2`,
 		} {
@@ -836,24 +837,29 @@ func dedupeDigests[T any](v []T, digest func(T) string) []string {
 }
 
 // indexManifest parses a manifest body, records which blobs it references (for
-// image manifests), and stores the manifest's size:
+// image manifests) or which child manifests it references (for image indexes),
+// and stores the manifest's size:
 //   - image manifest: size is the sum of its blob sizes (config + layers).
 //   - image index / manifest list: size is the sum of its children's sizes; if
 //     any child is not yet indexed, size is left NULL so the next index pass
-//     retries once the children have been sized.
+//     retries once the children have been sized. Child digests are always
+//     recorded so registry.gc can keep platform manifests of a live index.
 func (a *App) indexManifest(ctx context.Context, repository, manifestDigest string, body []byte) error {
 	var m manifestContent
 	if err := json.Unmarshal(body, &m); err != nil {
 		return err
 	}
 
-	// Image index / manifest list: sum the children's sizes.
+	// Image index / manifest list: record children, then sum their sizes.
 	if len(m.Manifests) > 0 {
 		children := dedupeDigests(m.Manifests, func(c struct {
 			Digest string `json:"digest"`
 		}) string {
 			return c.Digest
 		})
+		if err := a.recordManifestChildren(ctx, repository, manifestDigest, children); err != nil {
+			return err
+		}
 		if len(children) == 0 {
 			return a.setManifestSize(ctx, repository, manifestDigest, 0)
 		}
@@ -897,6 +903,23 @@ func (a *App) indexManifest(ctx context.Context, repository, manifestDigest stri
 	return a.sizeImageFromBlobs(ctx, repository, manifestDigest)
 }
 
+// recordManifestChildren stores index → child-manifest digests for GC keep-set
+// expansion. Idempotent.
+func (a *App) recordManifestChildren(ctx context.Context, repository, parentDigest string, children []string) error {
+	if len(children) == 0 {
+		return nil
+	}
+	_, err := pgstmt.Insert(func(b pgstmt.InsertStatement) {
+		b.Into("manifest_children")
+		b.Columns("repository", "parent_digest", "child_digest")
+		for _, child := range children {
+			b.Value(repository, parentDigest, child)
+		}
+		b.OnConflictDoNothing()
+	}).ExecWith(ctx)
+	return err
+}
+
 func (a *App) setManifestSize(ctx context.Context, repository, manifestDigest string, size int64) error {
 	_, err := pgctx.Exec(ctx, `
 		update manifests
@@ -916,10 +939,12 @@ func (a *App) readManifestBody(ctx context.Context, repository, digest string) (
 	return io.ReadAll(rc)
 }
 
-// rebuildManifestBlobsIndex fetches every manifest whose size has not been
-// computed yet, reads its content from GCS, and indexes it (blob refs + size).
-// Image manifests are processed before image indexes so an index can sum its
-// already-sized children within a single pass.
+// rebuildManifestBlobsIndex fetches every manifest that still needs indexing:
+// size not yet computed, or a sized index missing manifest_children rows
+// (backfill after the children table was introduced). Reads content from GCS
+// and records blob refs / child refs + size. Image manifests are processed
+// before image indexes so an index can sum its already-sized children within a
+// single pass.
 func (a *App) rebuildManifestBlobsIndex(ctx context.Context) error {
 	type manifestID struct {
 		repository string
@@ -948,6 +973,21 @@ func (a *App) rebuildManifestBlobsIndex(ctx context.Context) error {
 			)
 		from manifests m
 		where m.size is null
+		   or (
+		        -- Sized image indexes with no blob refs and no child links yet:
+		        -- backfill manifest_children so registry.gc can retain platforms.
+		        -- size > 0 excludes empty images (no layers) that would otherwise
+		        -- match forever (no blobs, no children).
+		        m.size > 0
+		        and not exists (
+		            select 1 from manifest_blobs mb
+		            where mb.repository = m.repository and mb.manifest_digest = m.digest
+		        )
+		        and not exists (
+		            select 1 from manifest_children mc
+		            where mc.repository = m.repository and mc.parent_digest = m.digest
+		        )
+		   )
 	`)
 	if err != nil {
 		return fmt.Errorf("query unindexed manifests: %w", err)

--- a/schema.sql
+++ b/schema.sql
@@ -42,6 +42,18 @@ create table manifest_blobs (
 );
 create index manifest_blobs_blob_idx on manifest_blobs (repository, blob_digest);
 
+-- Image index / manifest list → child manifest digests. Used by registry.gc so
+-- a kept multi-arch index also retains its platform manifests (and thus their
+-- layer blobs via manifest_blobs).
+create table manifest_children (
+	repository    text not null,
+	parent_digest text not null,
+	child_digest  text not null,
+	primary key (repository, parent_digest, child_digest),
+	foreign key (repository, parent_digest) references manifests (repository, digest)
+);
+create index manifest_children_child_idx on manifest_children (repository, child_digest);
+
 create table project_storage_usage (
 	namespace  text        not null primary key,
 	size       bigint      not null default 0,


### PR DESCRIPTION
## Summary

Registry blob GC was able to delete layer blobs still needed by a live multi-arch image.

**Root cause**
1. Image indexes (manifest lists) were never recorded in a parent→child table—only image manifests wrote `manifest_blobs` for layers.
2. `registry.gc` (apiserver) kept the index digest when a deployment used `:tag`, but deleted untagged platform child manifests as "unused".
3. Blob GC then saw those children's layers as unreferenced and deleted them while the index tag was still live.

**This PR (registry service)**
- Add `manifest_children` table; write child digests when indexing an image index (including when size is still pending).
- `indexManifests` backfills children for sized indexes missing those rows (`size > 0`, no blob refs, no children).
- Blob GC skips repositories with any `manifests.size is null` (incomplete indexing).
- Blob GC deletes the DB row only if still unreferenced, then removes the GCS object.

**Companion PR:** apiserver expands the GC keep-set via `manifest_children` (must land with this).

## Ops

Apply before/with deploy:

```sql
create table if not exists registry.manifest_children (
  repository    text not null,
  parent_digest text not null,
  child_digest  text not null,
  primary key (repository, parent_digest, child_digest),
  foreign key (repository, parent_digest) references registry.manifests (repository, digest)
);
create index if not exists manifest_children_child_idx
  on registry.manifest_children (repository, child_digest);
```

Then trigger `POST /internal/indexManifests` (or `/internal/runAll`) once to backfill existing multi-arch indexes.

## Test plan

- [ ] Apply DDL on staging
- [ ] Deploy registry; run `indexManifests`; confirm `manifest_children` rows for multi-arch repos
- [ ] Push multi-arch image, deploy by tag, run `registry.gc` (apiserver fix) + blob GC; platform layers remain
- [ ] Confirm unreferenced single-arch garbage is still reclaimed after 1 day