### PR TITLE
chore: bump Go to 1.27.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.3
+golang 1.27.0

--- a/auth_test.go
+++ b/auth_test.go
@@ -192,12 +192,10 @@ func TestCheckPermission_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
-			results[idx] = checkPermissionWithID(ctx, "sfproject", permPull)
-		}(i)
+			results[i] = checkPermissionWithID(ctx, "sfproject", permPull)
+		})
 	}
 	close(start)
 	wg.Wait()
@@ -254,12 +252,10 @@ func TestGetEmail_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
-			emails[idx] = getEmail(context.Background(), token)
-		}(i)
+			emails[i] = getEmail(context.Background(), token)
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module moonrhythm/registry
 
-go 1.26.3
+go 1.27.0
 
 replace github.com/lib/pq => github.com/moonrhythm/pq v0.0.0-20230504040008-09b0644d6569
 
 require (
 	cloud.google.com/go/storage v1.62.1
-	github.com/acoshift/arpc/v2 v2.2.0
 	github.com/acoshift/configfile v1.9.0
 	github.com/acoshift/pgsql v0.16.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/acoshift/arpc/v2 v2.2.0 h1:OKcFyMtoZULVfs4Gfa5AQOVItaTNIgTIuOb2YzKz9AA=
-github.com/acoshift/arpc/v2 v2.2.0/go.mod h1:EZ7M0MpTTDhD8+9k+PbvGGFAoHDhs12442A6VpNDS7A=
 github.com/acoshift/configfile v1.9.0 h1:/t8DhgBdYIr15f4BkkM4bDSBWi0+ImKwWgJN/M5Hbb0=
 github.com/acoshift/configfile v1.9.0/go.mod h1:4T3q2BRRhEW4lcS0vc1Pruv0/TuBVKOb7F5vUp6ZyAY=
 github.com/acoshift/pgsql v0.16.0 h1:ak+fwy8Xnx0uZBhSmvFhGGk3a7EQNu8IiRLpnP99IT4=

--- a/migrate/r2togcs/main.go
+++ b/migrate/r2togcs/main.go
@@ -176,8 +176,10 @@ func copyObject(ctx context.Context, r2 *s3.Client, r2Bucket string, gcsBucket *
 // digestFromKey returns the digest if it is encoded in the object key, or empty
 // string for tag-addressed manifests where the digest must be computed.
 func digestFromKey(key string) string {
-	parts := strings.Split(key, "/")
-	last := parts[len(parts)-1]
+	last := key
+	if _, after, ok := strings.CutLast(key, "/"); ok {
+		last = after
+	}
 	if strings.HasPrefix(last, "sha256:") {
 		return last
 	}


### PR DESCRIPTION
- go.mod: 1.26.3 -> 1.27.0
- .tool-versions: golang 1.27.0

go mod tidy dropped unused github.com/acoshift/arpc/v2 (not imported).