### PR TITLE
chore: modernize to Go 1.27 idioms

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -192,12 +192,10 @@ func TestCheckPermission_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
-			results[idx] = checkPermissionWithID(ctx, "sfproject", permPull)
-		}(i)
+			results[i] = checkPermissionWithID(ctx, "sfproject", permPull)
+		})
 	}
 	close(start)
 	wg.Wait()
@@ -254,12 +252,10 @@ func TestGetEmail_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
-			emails[idx] = getEmail(context.Background(), token)
-		}(i)
+			emails[i] = getEmail(context.Background(), token)
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/migrate/r2togcs/main.go
+++ b/migrate/r2togcs/main.go
@@ -176,8 +176,10 @@ func copyObject(ctx context.Context, r2 *s3.Client, r2Bucket string, gcsBucket *
 // digestFromKey returns the digest if it is encoded in the object key, or empty
 // string for tag-addressed manifests where the digest must be computed.
 func digestFromKey(key string) string {
-	parts := strings.Split(key, "/")
-	last := parts[len(parts)-1]
+	last := key
+	if _, after, ok := strings.CutLast(key, "/"); ok {
+		last = after
+	}
 	if strings.HasPrefix(last, "sha256:") {
 		return last
 	}


### PR DESCRIPTION
## What

Behavior-preserving modernization to Go 1.27 idioms, stacked on `chore/go-1.27.0`.

`go fix -omitzero=false ./...` made no changes (already modernized through 1.26).

### Changes
- Replace `wg.Add(1)` / `go` / `defer wg.Done()` with `wg.Go` in singleflight tests (Go 1.25)
- Use `strings.CutLast` to take the last path segment in `digestFromKey` (Go 1.27)

### Safety
- **No functional change** — `WaitGroup.Go` matches Add/Done; `CutLast` matches `strings.Split` on the last `/`.
- JSON `omitzero` rewrites, `encoding/json/v2`, and UUID migration were not applied (custom `newUUID` left as-is).
- `go build ./...`, `go vet ./...`, and `go test ./... -count=1 -timeout 300s` all pass.